### PR TITLE
Fix "Medal Decompiler Crasher"

### DIFF
--- a/luau-lifter/src/lifter.rs
+++ b/luau-lifter/src/lifter.rs
@@ -485,11 +485,14 @@ impl<'a> Lifter<'a> {
                             (a..a + (b - 1))
                                 .map(|r| self.register(r as _).into())
                                 .collect()
-                        } else {
-                            let (tail, end) = top.take().unwrap();
+                        } else if let Some((tail, end)) = top.take() {
                             (a..end)
                                 .map(|r| self.register(r as _).into())
                                 .chain(std::iter::once(tail))
+                                .collect()
+                        } else {
+                            (a..self.function_list[self.function.id].max_stack_size)
+                                .map(|r| self.register(r as _).into())
                                 .collect()
                         };
                         statements.push(ast::Return::new(values).into());


### PR DESCRIPTION
The previous logic for handling variable returns (OpCode::LOP_RETURN where b=0) used `top.take().unwrap()`. This could cause a panic if the stack top marker was not available.

This change:
1. Replaces the `unwrap()` with a safe `if let Some(...)` to handle the normal variable return case.
2. Introduces a new `else` block to act as a fallback when `b=0` and `top` is `None`, correctly assuming the return values span from register A up to the function's max stack size.

Fixes https://devforum.roblox.com/t/medal-decompiler-crasher/4004040